### PR TITLE
Update PHP-CS-Fixer to v2.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+.idea/
 .php_cs.cache
+
+# Libraries should ignore the lock file
+composer.lock
+
+vendor/

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,14 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 use Mollie\PhpCodingStandards\PhpCsFixer\Rules;
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
-    ->name('.php_cs.dist')       // Fix this file as well
+    ->name('.php_cs.dist') // Fix this file as well
     ->in(__DIR__);
+
+$overrides = [
+    'declare_strict_types' => true,
+];
 
 return Config::create()
     ->setFinder($finder)
     ->setRiskyAllowed(true)
-    ->setRules(Rules::getForPhp71());
+    ->setRules(Rules::getForPhp71($overrides));

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ dist: xenial
 matrix:
   fast_finish: true
   allow_failures:
+    - php: 7.4snapshot
     - php: nightly
   include:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4snapshot
     - php: nightly
 
 sudo: false
@@ -27,4 +29,4 @@ install:
 script:
   - composer validate --strict
   - find src -name *.php | xargs -n 1 php -l
-  - vendor/bin/php-cs-fixer fix --dry-run
+  - vendor/bin/php-cs-fixer fix -v --dry-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+dist: xenial
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+  include:
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: nightly
+
+sudo: false
+
+cache:
+  directories:
+    - "$HOME/.composer/cache"
+
+env:
+  - COMPOSER_NO_INTERACTION=1
+
+install:
+  - travis_retry composer install --no-suggest
+
+script:
+  - composer validate --strict
+  - find src -name *.php | xargs -n 1 php -l
+  - vendor/bin/php-cs-fixer fix --dry-run

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.1.3",
-        "friendsofphp/php-cs-fixer": "^2.15"
+        "friendsofphp/php-cs-fixer": "^2.16"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mollie/php-coding-standards",
     "description": "Contains PHP coding standards like rules for PHP-CS-Fixer that serves for purpose of standardization.",
-    "license": "proprietary",
+    "license": "BSD-2-Clause",
     "type": "library",
     "authors": [
         {

--- a/src/PhpCsFixer/Rules.php
+++ b/src/PhpCsFixer/Rules.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mollie\PhpCodingStandards\PhpCsFixer;
 
 /*
- * Last updated for php-cs-fixer version: 2.15
+ * Last updated for php-cs-fixer version: 2.16
  */
 class Rules
 {
@@ -46,10 +46,7 @@ class Rules
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],
-            'array_indentation' => true,
-            'array_syntax'      => [
-                'syntax' => 'short',
-            ],
+            'array_indentation'      => true,
             'binary_operator_spaces' => [
                 'default' => 'align_single_space_minimal',
             ],
@@ -75,6 +72,7 @@ class Rules
             'explicit_string_variable'     => true,
             'fully_qualified_strict_types' => true,
             'function_to_constant'         => true,
+            'global_namespace_import'      => true,
             // 'header_comment'            => [ // Has too many issues atm
             //     'header' => '',
             // ],
@@ -105,14 +103,15 @@ class Rules
                     // TODO: Add 'use' when php-cs-fixer #3582 is fixed
                 ],
             ],
-            'no_null_property_initialization' => true,
-            'no_superfluous_elseif'           => true,
-            'no_superfluous_phpdoc_tags'      => true,
-            'no_unset_cast'                   => true,
-            'no_unset_on_property'            => false, // It's purposely used for the side effect :(
-            'no_useless_else'                 => true,
-            'no_useless_return'               => true,
-            'ordered_class_elements'          => [
+            'no_null_property_initialization'                  => true,
+            'no_superfluous_elseif'                            => true,
+            'no_superfluous_phpdoc_tags'                       => true,
+            'no_unset_cast'                                    => true,
+            'no_unset_on_property'                             => false, // It's purposely used for the side effect :(
+            'no_useless_else'                                  => true,
+            'no_useless_return'                                => true,
+            'nullable_type_declaration_for_default_null_value' => true,
+            'ordered_class_elements'                           => [
                 'order' => [
                     'use_trait',
                     'constant_public', 'constant_protected', 'constant_private',
@@ -123,6 +122,12 @@ class Rules
             'ordered_imports' => [
                 'imports_order' => ['class', 'function', 'const'],
             ],
+            'phpdoc_line_span' => [
+                'const'    => 'single',
+                'method'   => 'multi',
+                'property' => 'single',
+            ],
+            'phpdoc_no_empty_return'                 => true,
             'php_unit_construct'                     => true,
             'php_unit_dedicate_assert_internal_type' => true,
             'php_unit_method_casing'                 => true,
@@ -149,6 +154,7 @@ class Rules
             'simple_to_complex_string_variable'   => true,
             'simplified_null_return'              => false, // Too many old code places that become implicit, also ignores doc blocks.
             'single_class_element_per_statement'  => true,
+            'single_line_throw'                   => false,
             'single_quote'                        => false,
             'single_trait_insert_per_statement'   => true,
             'space_after_semicolon'               => [


### PR DESCRIPTION
All rule-changes either follow already existing standards or have been voted upon.

Also contains some random small fixes and improvements.