### PR TITLE
Remove deprecation errors

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,14 +7,14 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
-    ->name('.php_cs.dist') // Fix this file as well
+    ->name('.php-cs-fixer.dist.php') // Fix this file as well
     ->in(__DIR__);
 
 $overrides = [
     'declare_strict_types' => true,
 ];
 
-return Config::create()
+return (new Config())
     ->setFinder($finder)
     ->setRiskyAllowed(true)
     ->setRules(Rules::getForPhp71($overrides));

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,7 +7,6 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
-    ->name('.php-cs-fixer.dist.php') // Fix this file as well
     ->in(__DIR__);
 
 $overrides = [

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $config->setRules(Rules::getForPhp73());
 
 ### New to PHP-CS-Fixer
 
-Place a file named `.php_cs.dist` that has following content in your project's root directory.
+Place a file named `.php-cs-fixer.dist.php` that has the following content in your project's root directory.
 
 ```php
 <?php 
@@ -34,10 +34,10 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
-    ->name('.php_cs.dist') // Fix this file as well
+    ->name('.php-cs-fixer.dist.php') // Fix this file as well
     ->in(__DIR__);
 
-return Config::create()
+return (new Config())
     ->setFinder($finder)
     ->setRiskyAllowed(true)
     // use specific rules for your php version e.g.: getForPhp71, getForPhp72, getForPhp73

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
-    ->name('.php-cs-fixer.dist.php') // Fix this file as well
     ->in(__DIR__);
 
 return (new Config())

--- a/src/PhpCsFixer/Rules.php
+++ b/src/PhpCsFixer/Rules.php
@@ -79,9 +79,6 @@ class Rules
             'increment_style' => [
                 'style' => 'post',
             ],
-            'is_null' => [
-                'use_yoda_style' => false,
-            ],
             'list_syntax' => [
                 'syntax' => 'short',
             ],


### PR DESCRIPTION
- Move .php_cs.dist to .php-cs-fixer.dist.php
- Stopped using deprecated Config::create()
- removed deprecated `use_yoda_style` : this is already taken care of by `yoda_style` fixer
- Updated README

![image](https://user-images.githubusercontent.com/88372662/127987202-8d5be9c8-01b0-43f0-a3e0-582640f7bc82.png)
