### PR TITLE
Upgrade to cs-fixer 3 and add union types spacing rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^3.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/PhpCsFixer/Rules.php
+++ b/src/PhpCsFixer/Rules.php
@@ -155,6 +155,9 @@ class Rules
                 'remove_in_empty_for_expressions' => true,
             ],
             'ternary_to_null_coalescing' => true,
+            'types_spaces' => [
+                'space' => 'single', // Added to keep previous behaviour with the cs-fixer 3.1.0 upgrade.
+            ],
             'visibility_required' => [
                 'elements' => [
                     'const', 'method', 'property',


### PR DESCRIPTION
The added `types_spaces` rule keeps things as they are: this is the current behaviour in 2.19.
The other change the upgrade makes is converting `get_class($this)` to `static::class` which I think is desirable behaviour. 