### PR TITLE
Added support for 8.0 and 8.1 rules

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -18,6 +18,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "mollie/php-coding-standards",
-    "type": "library",
     "description": "Contains PHP coding standards like rules for PHP-CS-Fixer that serves for purpose of standardization.",
     "license": "BSD-2-Clause",
+    "type": "library",
     "authors": [
         {
             "name": "Mollie B.V.",
@@ -13,10 +13,10 @@
         "php": "^7.1.3 || ^8.0",
         "friendsofphp/php-cs-fixer": "^3.1.0"
     },
+    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "Mollie\\PhpCodingStandards\\": "src/"
         }
-    },
-    "minimum-stability": "stable"
+    }
 }

--- a/src/PhpCsFixer/Rules.php
+++ b/src/PhpCsFixer/Rules.php
@@ -9,11 +9,17 @@ namespace Mollie\PhpCodingStandards\PhpCsFixer;
  */
 class Rules
 {
+    /**
+     * @deprecated php version 7.1 is no longer supported
+     */
     public static function getForPhp71(array $overriddenRules = []): array
     {
         return array_merge(self::getBaseRules(), $overriddenRules);
     }
 
+    /**
+     * @deprecated php version 7.2 is no longer supported
+     */
     public static function getForPhp72(array $overriddenRules = []): array
     {
         $specific72Rules = [
@@ -23,6 +29,9 @@ class Rules
         return array_merge(self::getForPhp71($specific72Rules), $overriddenRules);
     }
 
+    /**
+     * @deprecated php version 7.3 is no longer supported
+     */
     public static function getForPhp73(array $overriddenRules = []): array
     {
         $specific73Rules = [
@@ -37,6 +46,33 @@ class Rules
         ];
 
         return array_merge(self::getForPhp72($specific73Rules), $overriddenRules);
+    }
+
+    public static function getForPhp74(array $overriddenRules = []): array
+    {
+        $specific74Rules = [
+            // At the moment there are no specific 7.4 rules or configurations
+        ];
+
+        return array_merge(self::getForPhp73($specific74Rules), $overriddenRules);
+    }
+
+    public static function getForPhp80(array $overriddenRules = []): array
+    {
+        $specific80Rules = [
+            // At the moment there are no specific 8.0 rules or configurations
+        ];
+
+        return array_merge(self::getForPhp74($specific80Rules), $overriddenRules);
+    }
+
+    public static function getForPhp81(array $overriddenRules = []): array
+    {
+        $specific81Rules = [
+            'declare_strict_types' => true,
+        ];
+
+        return array_merge(self::getForPhp80($specific81Rules), $overriddenRules);
     }
 
     private static function getBaseRules(): array
@@ -95,6 +131,11 @@ class Rules
                     'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block',
                     'return', 'square_brace_block', 'throw', 'use_trait',
                     // TODO: Add 'use' when php-cs-fixer #3582 is fixed
+                ],
+            ],
+            'class_attributes_separation' => [
+                'elements' => [
+                    'trait_import' => 'none',
                 ],
             ],
             'no_null_property_initialization' => true,


### PR DESCRIPTION
Removed deprecated rule `no_extra_blank_lines` for `use_traits` and added alternative

Added declare_strict_types rule for 8.1+ projects