### PR TITLE
Remove deprecated option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .php_cs.cache
+.php-cs-fixer.cache
 
 # Libraries should ignore the lock file
 composer.lock

--- a/src/PhpCsFixer/Rules.php
+++ b/src/PhpCsFixer/Rules.php
@@ -138,8 +138,7 @@ class Rules
             'no_extra_blank_lines' => [
                 'tokens' => [
                     'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block',
-                    'return', 'square_brace_block', 'throw', 'use_trait',
-                    // TODO: Add 'use' when php-cs-fixer #3582 is fixed
+                    'return', 'square_brace_block', 'throw',
                 ],
             ],
             'class_attributes_separation' => [


### PR DESCRIPTION
This solves this error:

```
Detected deprecations in use:
- Option "tokens: use_trait" used in `no_extra_blank_lines` rule is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.
```

The `TODO` could also be removed as that is now handled in `class_attributes_separation`.