### PR TITLE
Change rule phpdoc_align from vertical to left

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ strong opinions, and, most importantly, who know how to ship great products. Wan
 
 ## License
 [BSD (Berkeley Software Distribution) License](https://opensource.org/licenses/bsd-license.php).
-Copyright (c) 2023, Mollie B.V.
+Copyright (c) 2025, Mollie B.V.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^3.64"
+        "friendsofphp/php-cs-fixer": "^3.68"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/src/PhpCsFixer/Rules.php
+++ b/src/PhpCsFixer/Rules.php
@@ -186,6 +186,7 @@ class Rules
             'php_unit_test_case_static_method_calls' => [
                 'call_type' => 'self',
             ],
+            'phpdoc_align' => ['align' => 'left'], // Prevent modifying multiple lines when changing one param in a docblock
             'phpdoc_annotation_without_dot' => false, // Sometimes comments have a good reason to end with a dot. Leave this up to the engineer.
             'phpdoc_no_alias_tag' => [
                 'replacements' => [


### PR DESCRIPTION
Prevent modifying multiple lines when changing one param in a docblock.

Changed rule `phpdoc_align` from [vertical](https://cs.symfony.com/doc/rules/phpdoc/phpdoc_align.html#example-2) to [left](https://cs.symfony.com/doc/rules/phpdoc/phpdoc_align.html#example-3).